### PR TITLE
Add envs and update docs for Windows-specific setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# https://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 *.marko.js
 # Build assets
 **/dist/
+**/node_modules/**/*

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js  text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
-*.js  text eol=lf
+* text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
+  "files.eol": "\n",
   "eslint.validate": [ "javascript" ]
 }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # Newsletters for AC Business Media
+
+## Requirements
+- docker-compose
+
+or
+
+- Node >= v10.x
+- Yarn package manager
+
+## Installation
+To install this repository, execute the `./scripts/yarn.sh` or `./scripts/yarn.bat` script from the project root.
+
+## Development
+To work in this repository, start the newsletter instance for your chosen tenant (such as `fcp`):
+```
+docker-compose up fcp
+```
+
+To run the test suite, execute the `./scripts/test.sh` or `./scripts/test.bat` script from the project root.
+
+For more details about working with the Marko newsletter framework, check out the [docs](https://docs.parameter1.com)!
+
+### On Windows
+Due to an issue with [Docker for Windows](https://forums.docker.com/t/file-system-watch-does-not-work-with-mounted-volumes/12038/16), file watching is not supported inside a container. If you are using `docker-compose` with this project on a Microsoft Windows system, you'll need to ensure that the backup file watching method (polling for file modification dates at a specified interval) is used. To enable polling, create a `.env` file at the root of this project and add the following line:
+```
+GULP_POLLING_ENABLED=true
+```
+
+If you need to adjust the polling interval, you can do so by adding `GULP_POLLING_INTERVAL=<value in milliseconds>` to this file. The default is 1000ms.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ x-env-defaults: &env
   NODE_ENV: development
   NEW_RELIC_ENABLED: ${NEW_RELIC_ENABLED-0}
   NEW_RELIC_LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY-(unset)}
+  GULP_POLLING_ENABLED: ${GULP_POLLING_ENABLED-0}
+  GULP_POLLING_INTERVAL: ${GULP_POLLING_INTERVAL-1000}
 
 x-env-tauron: &env-tauron
   GRAPHQL_URI: ${GRAPHQL_URI-https://tauron.graphql.base.parameter1.com}

--- a/scripts/test.bat
+++ b/scripts/test.bat
@@ -1,0 +1,3 @@
+@echo off
+
+docker-compose run --rm yarn test

--- a/scripts/yarn.bat
+++ b/scripts/yarn.bat
@@ -1,0 +1,3 @@
+@echo off
+
+docker-compose run --rm yarn


### PR DESCRIPTION
Requires parameter1/base-cms#40

Updates docs to provide a basic intro to the repo, add batch scripts, and provide instructions for developing on Windows.