### PR TITLE
Styling changes to footer, sponsored & mid blocks

### DIFF
--- a/packages/common/components/blocks/content/new-mid.marko
+++ b/packages/common/components/blocks/content/new-mid.marko
@@ -84,8 +84,8 @@ $ const buttonTextStyle = {
                   <marko-newsletter-imgix
                     src=image.src
                     alt=image.alt
-                    options={ w: 324, h: 248, fit: "crop" }
-                    attrs={ align: "center", width: 324, height: 248 }
+                    options={ w: 324, h: 253 }
+                    attrs={ align: "center", width: 324, height: 253 }
                     class="resize_img"
                   />
                 </marko-core-obj-value>

--- a/packages/common/components/blocks/content/new-sponsored-list.marko
+++ b/packages/common/components/blocks/content/new-sponsored-list.marko
@@ -15,7 +15,7 @@ $ const {
 
 $ const nameStyle = {
   "font-family": "'Arial', sans-serif",
-  "font-size": "11px",
+  "font-size": "13px",
   "line-height": "16px",
   "color": "#000000",
   "font-weight": "bold",
@@ -75,7 +75,7 @@ $ const sponsoredNameStyle = {
                               </marko-newsletter-imgix>
                             </marko-core-obj-value>
                           </td>
-                          <td align="center" valign="top" width="55%" style="height: 144">
+                          <td align="center" valign="top" width="55%">
                             <table width="96%" align="right" border="0" cellspacing="0" cellpadding="0">
                               <tr>
                                 <td>

--- a/packages/common/components/blocks/new-standard-footer.marko
+++ b/packages/common/components/blocks/new-standard-footer.marko
@@ -10,8 +10,8 @@ $ const socialMediaLinks = getAsArray(socialMedia, "links");
 
 $ const standardStyle = {
   "font-family": "'Arial', sans-serif",
-  "font-size": "9px",
-  "line-height": "12px",
+  "font-size": "5px",
+  "line-height": "8px",
   "color": "#ffffff",
   "font-weight": "normal",
   "letter-spacing": "0",
@@ -19,7 +19,7 @@ $ const standardStyle = {
 
 $ const smallerStyle = {
   ...standardStyle,
-  "line-height": "9px",
+  "line-height": "5px",
 };
 
 $ const linkStyle = {
@@ -76,7 +76,7 @@ $ const linkStyle = {
               <common-table-spacer-element height=3 />
               <tr>
                 <td align="center"  class="align" valign="middle" style=standardStyle>
-                  Please add news.acbmmail.com and marketing.acbmmail.com to your address book or<br/>safe sender list to receive our emails in your inbox.
+                  Please add news.acbmmail.com and marketing.acbmmail.com to your address book or safe sender list to receive our emails in your inbox.
                 </td>
               </tr>
               <common-table-spacer-element height=3 />
@@ -95,13 +95,13 @@ $ const linkStyle = {
                   If this email was forwarded to you and you are interested in subscribing, please <a href=get(newsletterConfig, "newsletterPrefLink") style=linkStyle>click here</a> to sign-up.
                 </td>
               </tr>
-              <common-table-spacer-element height=5 />
+              <common-table-spacer-element height=3 />
               <tr>
                 <td align="center"  class="align" valign="middle" style=standardStyle>
                   If you have any questions or concerns, please contact us at 920-542-1131 or toll-free at 800-538-5544.
                 </td>
               </tr>
-              <common-table-spacer-element height=5 />
+              <common-table-spacer-element height=3 />
               <tr>
                 <td align="center"  class="align" valign="middle" style=smallerStyle>${website.get("name")}<br>
                   AC Business Media<br>


### PR DESCRIPTION
Before height adjustment:
<img width="986" alt="Screen Shot 2021-09-15 at 11 38 14 AM" src="https://user-images.githubusercontent.com/64623209/133474489-2e69f8b1-72f9-4bf0-9278-3770405c8f1f.png">
After height adjustment:
<img width="682" alt="Screen Shot 2021-09-15 at 11 37 46 AM" src="https://user-images.githubusercontent.com/64623209/133474573-35f0fe48-d0c7-4583-85f0-24ecb208537d.png">
Footer:
<img width="619" alt="Screen Shot 2021-09-15 at 11 06 19 AM" src="https://user-images.githubusercontent.com/64623209/133474602-bfc007b3-6be3-421e-be28-de963095ad7d.png">
Sponsored:
<img width="674" alt="Screen Shot 2021-09-15 at 11 06 11 AM" src="https://user-images.githubusercontent.com/64623209/133474641-58a5970f-475b-4c10-a3db-52d183ebc0d2.png">
