### PR TITLE
Make styling changes to headline news

### DIFF
--- a/packages/common/components/blocks/content/new-featured.marko
+++ b/packages/common/components/blocks/content/new-featured.marko
@@ -168,7 +168,7 @@ $ const buttonTextStyle = {
               <td align="center" valign="top">
                 <table width="88%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap100">
                   <tr>
-                    <td align="left" class="mob_hide" valign="middle">
+                    <td align="left" valign="middle">
                       <marko-core-obj-text obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                     </td>
                   </tr>

--- a/packages/common/components/blocks/content/new-list.marko
+++ b/packages/common/components/blocks/content/new-list.marko
@@ -35,6 +35,7 @@ $ const titleStyle = {
   "color": "#000000",
   "font-weight": "900",
   "letter-spacing": "0",
+  "text-decoration": "none"
 };
 
 $ const teaserStyle = {
@@ -109,7 +110,9 @@ $ const linkStyle = {
                             <td align="left" valign="middle" style=borderStyle></td>
                             <td align="left" valign="middle" width="7px"></td>
                             <td align="left" class="font6" valign="middle" style=titleStyle>
-                              <marko-core-obj-text obj=node field="name" html=true attrs={ style: titleStyle } />
+                              <marko-core-obj-text obj=node field="name" html=true >
+                                <@link href=node.siteContext.url target="_blank" attrs={ style: titleStyle }/>
+                              </marko-core-obj-text>
                             </td>
                         </tr>
                       </table>

--- a/packages/common/components/blocks/content/new-mid.marko
+++ b/packages/common/components/blocks/content/new-mid.marko
@@ -19,6 +19,7 @@ $ const nameStyle = {
   "line-height": "30px",
   "color": "#ffffff",
   "font-weight": "900",
+  "text-decoration": "none !important"
 };
 
 $ const mobileStyle = {
@@ -27,6 +28,7 @@ $ const mobileStyle = {
   "line-height": "18px",
   "color": "#000000",
   "font-weight": "900",
+  "text-decoration": "none !important"
 };
 
 $ const verticalBorderStyle = {
@@ -50,6 +52,7 @@ $ const teaserStyle = {
   "color": "#A4A09F",
   "font-weight": "400",
   "letter-spacing": "-0.2px",
+  "text-decoration": "none !important"
 };
 
 $ const buttonStyle = {
@@ -79,7 +82,7 @@ $ const buttonTextStyle = {
         <td align="center" valign="top">
           <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101">
             <tr>
-              <td valign="top" width="60%" class="flt1">
+              <td valign="center" width="60%" class="flt1">
                 <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
                   <marko-newsletter-imgix
                     src=image.src
@@ -87,14 +90,18 @@ $ const buttonTextStyle = {
                     options={ w: 324, h: 253 }
                     attrs={ align: "center", width: 324, height: 253 }
                     class="resize_img"
-                  />
+                  >
+                    <@link href=node.siteContext.url target="_blank" attrs={ style: nameStyle} />
+                  </marko-newsletter-imgix>
                 </marko-core-obj-value>
               </td>
               <td align="center" valign="bottom" width="40%" class="flt1" bgcolor=primaryColor>
                 <table width="84%" align="center" border="0" cellspacing="0" cellpadding="0">
                   <tr>
                     <td align="left" class="mob_hide1" valign="bottom">
-                      <marko-core-obj-text obj=node field="name" html=true attrs={ style: nameStyle } />
+                      <marko-core-obj-text obj=node field="name" html=true >
+                        <@link href=node.siteContext.url target="_blank" attrs={ style: nameStyle }/>
+                      </marko-core-obj-text>
                     </td>
                   </tr>
                   <common-table-spacer-element height=13 />

--- a/packages/common/components/blocks/new-standard-footer.marko
+++ b/packages/common/components/blocks/new-standard-footer.marko
@@ -10,8 +10,8 @@ $ const socialMediaLinks = getAsArray(socialMedia, "links");
 
 $ const standardStyle = {
   "font-family": "'Arial', sans-serif",
-  "font-size": "5px",
-  "line-height": "8px",
+  "font-size": "8px",
+  "line-height": "12px",
   "color": "#ffffff",
   "font-weight": "normal",
   "letter-spacing": "0",
@@ -19,7 +19,7 @@ $ const standardStyle = {
 
 $ const smallerStyle = {
   ...standardStyle,
-  "line-height": "5px",
+  "line-height": "8px",
 };
 
 $ const linkStyle = {

--- a/packages/common/components/blocks/new-standard-header.marko
+++ b/packages/common/components/blocks/new-standard-header.marko
@@ -40,13 +40,6 @@ $ const textStyle = {
                 <td align="right" valign="top"  style=textStyle>
                   ${displayDate}
                 </td>
-              <!-- </tr>
-            </table>
-          </td>
-        </tr>
-        <common-table-spacer-element height=16 />
-        <tr> -->
-
               </tr>
             </table>
           </td>

--- a/packages/common/components/blocks/new-standard-header.marko
+++ b/packages/common/components/blocks/new-standard-header.marko
@@ -21,30 +21,34 @@ $ const textStyle = {
       <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101">
         <common-table-spacer-element height=10 />
         <tr>
-          <td align="center" valign="top">
-            <table width="100%" align="center" border="0" cellspacing="0" cellpadding="0">
+          <td valign="top">
+            <table width="100%" border="0" cellspacing="0" cellpadding="0">
               <tr>
-                <td width="200" align="right" class="mob_hide" valign="top" style=textStyle>
+                <td align="left" valign="top">
+                  <marko-newsletter-imgix
+                    src=`${newsletterConfig.headerLogoSrc}`
+                    alt="logo"
+                    options={ w: 85, h: 24 }
+                    attrs={ style: "margin: 0 0 0 8px !important; height: 24" }
+                  >
+                    <@link href=website.get("origin") target="_blank" />
+                  </marko-newsletter-imgix>
+                </td>
+                <td align="center" class="mob_hide" valign="top" style=textStyle>
                   <a href="@{mv_online_version}@" target="_blank" style=textStyle>View Email Online</a>
                 </td>
-                <td width="125" align="right" valign="top"  style=textStyle>
+                <td align="right" valign="top"  style=textStyle>
                   ${displayDate}
                 </td>
-              </tr>
+              <!-- </tr>
             </table>
           </td>
         </tr>
         <common-table-spacer-element height=16 />
-        <tr>
-          <td align="left" valign="top">
-            <marko-newsletter-imgix
-              src=`${newsletterConfig.headerLogoSrc}`
-              alt="logo"
-              options={ w: 85, h: 24 }
-              attrs={ style: "margin: 0 0 0 8px !important; height: 24" }
-            >
-              <@link href=website.get("origin") target="_blank" />
-            </marko-newsletter-imgix>
+        <tr> -->
+
+              </tr>
+            </table>
           </td>
         </tr>
         <common-table-spacer-element height=5 />


### PR DESCRIPTION
Center image with long titles:
<img width="677" alt="Screen Shot 2021-09-20 at 9 51 39 AM" src="https://user-images.githubusercontent.com/64623209/134023803-72f515eb-5fc8-4e92-b01c-73dd2ceeaef5.png">
