### PR TITLE
Decrease font-size & keep footer centered on mobile

### DIFF
--- a/packages/common/components/blocks/new-standard-footer.marko
+++ b/packages/common/components/blocks/new-standard-footer.marko
@@ -10,8 +10,8 @@ $ const socialMediaLinks = getAsArray(socialMedia, "links");
 
 $ const standardStyle = {
   "font-family": "'Arial', sans-serif",
-  "font-size": "8px",
-  "line-height": "12px",
+  "font-size": "7px",
+  "line-height": "10px",
   "color": "#ffffff",
   "font-weight": "normal",
   "letter-spacing": "0",
@@ -19,7 +19,7 @@ $ const standardStyle = {
 
 $ const smallerStyle = {
   ...standardStyle,
-  "line-height": "8px",
+  "line-height": "7px",
 };
 
 $ const linkStyle = {
@@ -43,8 +43,8 @@ $ const linkStyle = {
         </tr>
         <if(socialMediaLinks.length)>
           <tr bgcolor=primaryColor>
-            <td align="center" valign="top"  class="align">
-              <table align="center"  class="align" border="0" cellspacing="0" cellpadding="10">
+            <td align="center" valign="top"  class="align2">
+              <table align="center"  class="align2" border="0" cellspacing="0" cellpadding="10">
                 <tr>
                   <for|link| of=socialMediaLinks>
                     <td>
@@ -68,20 +68,20 @@ $ const linkStyle = {
             <table width="95%" align="center" border="0" cellspacing="0" cellpadding="0">
               <common-table-spacer-element height=19 />
               <tr>
-                <td align="center" class="align" valign="middle" style=standardStyle>
+                <td align="center" class="align2" valign="middle" style=standardStyle>
                   This email is being sent to
                     <a href="mailto:@{email name}@" style=linkStyle>@{email name}@</a>.
                 </td>
               </tr>
               <common-table-spacer-element height=3 />
               <tr>
-                <td align="center"  class="align" valign="middle" style=standardStyle>
+                <td align="center"  class="align2" valign="middle" style=standardStyle>
                   Please add news.acbmmail.com and marketing.acbmmail.com to your address book or safe sender list to receive our emails in your inbox.
                 </td>
               </tr>
               <common-table-spacer-element height=3 />
               <tr>
-                <td align="center"  class="align1" valign="middle" style=standardStyle>
+                <td align="center"  class="align3" valign="middle" style=standardStyle>
                   <a href=get(newsletterConfig, "newsletterPrefLink") style=linkStyle>Manage Newsletter Subscriptions</a>
                   | <a href="@{forwardtoafriendlink}@" style=linkStyle>Forward to a Friend</a>
                   | <a href="@{confirmunsubscribelink}@" style=linkStyle>Unsubscribe</a>
@@ -91,19 +91,19 @@ $ const linkStyle = {
               </tr>
               <common-table-spacer-element height=3 />
               <tr>
-                <td align="center"  class="align" valign="middle" style=standardStyle>
+                <td align="center"  class="align2" valign="middle" style=standardStyle>
                   If this email was forwarded to you and you are interested in subscribing, please <a href=get(newsletterConfig, "newsletterPrefLink") style=linkStyle>click here</a> to sign-up.
                 </td>
               </tr>
               <common-table-spacer-element height=3 />
               <tr>
-                <td align="center"  class="align" valign="middle" style=standardStyle>
+                <td align="center"  class="align2" valign="middle" style=standardStyle>
                   If you have any questions or concerns, please contact us at 920-542-1131 or toll-free at 800-538-5544.
                 </td>
               </tr>
               <common-table-spacer-element height=3 />
               <tr>
-                <td align="center"  class="align" valign="middle" style=smallerStyle>${website.get("name")}<br>
+                <td align="center"  class="align2" valign="middle" style=smallerStyle>${website.get("name")}<br>
                   AC Business Media<br>
                   201 N. Main Street<br>
                   Fort Atkinson, WI 53538

--- a/packages/common/components/new-standard-head-styles.marko
+++ b/packages/common/components/new-standard-head-styles.marko
@@ -58,6 +58,8 @@
         .wrap102{width: 100% !important;}
         .align{text-align: left !important;margin: 0 !important}
         .align1{text-align: left !important;text-decoration: underline;}
+        .align2{text-align: center !important;}
+        .align3{text-align: center !important; text-decoration: underline;}
       }
 
       @font-face {


### PR DESCRIPTION
Decreased font size:
<img width="548" alt="Screen Shot 2021-09-21 at 9 08 57 AM" src="https://user-images.githubusercontent.com/64623209/134186473-97b3867e-1528-4492-be7b-5b99f95e2084.png">
Mobile view (still centered):
<img width="424" alt="Screen Shot 2021-09-21 at 9 09 13 AM" src="https://user-images.githubusercontent.com/64623209/134186536-590a3f38-8d89-4101-b05b-1a3e5de67781.png">

