### PR TITLE
Fix mobile alignment of content in mid-block

### DIFF
--- a/packages/common/components/blocks/content/new-mid.marko
+++ b/packages/common/components/blocks/content/new-mid.marko
@@ -148,7 +148,7 @@ $ const buttonTextStyle = {
                   <common-table-spacer-element height=11 />
                   <tr>
                     <td align="left" valign="top">
-                      <table width="100%" align="right" border="0" cellspacing="0" cellpadding="0">
+                      <table width="100%" align="right" border="0" cellspacing="0" cellpadding="0" class="wrap103">
                         <tr>
                           <td align="left" valign="middle" class="font3">
                             <marko-core-obj-text obj=node field="teaser" attrs={ style: teaserStyle } />

--- a/packages/common/components/new-standard-head-styles.marko
+++ b/packages/common/components/new-standard-head-styles.marko
@@ -42,6 +42,7 @@
 
       @media(max-width:479px){
         .wrap100{width: 95% !important;}
+        .wrap103{width: 98% !important;}
         .mob_hide{display: none !important;}
         .mob_show{display: block !important;font-size: 13px !important;line-height: 18px !important;}
         .mob_show1{display: block !important;}


### PR DESCRIPTION
Mobile view:
<img width="611" alt="Screen Shot 2021-09-21 at 11 13 03 AM" src="https://user-images.githubusercontent.com/64623209/134208066-fa32176e-a70c-4fb0-8bb9-f8fea211aece.png">
