### PR TITLE
Increase template width to keep styling around ad slots

### DIFF
--- a/packages/common/components/blocks/content/new-featured.marko
+++ b/packages/common/components/blocks/content/new-featured.marko
@@ -14,6 +14,7 @@ $ const {
 $ const newsletterConfig = config.get(newsletter.alias);
 $ const primaryColor = get(newsletterConfig, "primaryColor");
 $ const editor = get(newsletterConfig, "editor");
+$ const editorTitle = get(newsletterConfig, "editorTitle");
 $ const brandName = get(newsletterConfig, "brandName");
 $ const editorImage = get(newsletterConfig, "editorImage");
 $ const waterMarkOptions = {
@@ -97,7 +98,7 @@ $ const buttonTextStyle = {
   queryFragment: contentList,
 }>
 
-  <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+  <table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
     <tr>
       <td align="center" valign="top">
         <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101">
@@ -115,7 +116,7 @@ $ const buttonTextStyle = {
   <for|node| of=nodes>
 
   $ const imgOptions = {
-    w: 540,
+    w: 600,
     h: 393,
     dpr: 2,
     fit: "crop",
@@ -125,7 +126,7 @@ $ const buttonTextStyle = {
   };
 
 
-    <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+    <table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
       <tr>
         <td align="center" valign="top">
           <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff" class="wrap101">
@@ -135,7 +136,7 @@ $ const buttonTextStyle = {
                   <marko-newsletter-imgix
                     src=image.src
                     options=imgOptions
-                    attrs={ align: "center", width: 540, height: 393 }
+                    attrs={ align: "center", width: 600, height: 393 }
                     class="resize_img"
                   >
                     <@link href=node.siteContext.url target="_blank" />
@@ -151,7 +152,7 @@ $ const buttonTextStyle = {
                       <table width="100%" align="left" valign="bottom" border="0" cellspacing="0" cellpadding="0">
                         <tr>
                           <td align="left" valign="middle" class="font3" style=editorStyle>
-                            ${editor} | Editor |
+                            ${editor} | ${editorTitle} |
                           </td>
                           <td style=brandNameStyle>
                             ${brandName}

--- a/packages/common/components/blocks/content/new-featured.marko
+++ b/packages/common/components/blocks/content/new-featured.marko
@@ -98,10 +98,10 @@ $ const buttonTextStyle = {
   queryFragment: contentList,
 }>
 
-  <table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+  <table width="660" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
     <tr>
       <td align="center" valign="top">
-        <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101">
+        <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101">
           <tr>
           $ const borderStyle = (longBorder) ? verticalBorderStyleThick : verticalBorderStyle;
             <td style=borderStyle>
@@ -126,10 +126,10 @@ $ const buttonTextStyle = {
   };
 
 
-    <table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+    <table width="660" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
       <tr>
         <td align="center" valign="top">
-          <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff" class="wrap101">
+          <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff" class="wrap101">
             <tr>
               <td valign="top">
                 <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">

--- a/packages/common/components/blocks/content/new-list.marko
+++ b/packages/common/components/blocks/content/new-list.marko
@@ -79,10 +79,10 @@ $ const linkStyle = {
 }>
 
   <if(displaySectionName === true)>
-    <table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+    <table width="660" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
       <tr>
         <td align="center" valign="top">
-          <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101">
+          <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101">
             <common-table-spacer-element class="height2" height=10 />
             <tr>
               <td align="center" valign="middle" class="font1" style=sectionNameStyle>TRENDING NEWS</td>
@@ -94,17 +94,17 @@ $ const linkStyle = {
     </table>
   </if>
   <for|node| of=nodes>
-    <table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+    <table width="660" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
       <tr>
         <td align="center" valign="top">
-          <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101" bgcolor="#ffffff">
+          <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101" bgcolor="#ffffff">
             <tr>
               <td align="center" valign="top">
-                <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap100">
+                <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap100">
                   <common-table-spacer-element class="height2" height=18 />
                   <tr>
                     <td align="left" valign="top">
-                      <table width="100%" align="left" border="0" cellspacing="0" cellpadding="0">
+                      <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0">
                         <tr>
                           $ const borderStyle = (longBorder) ? verticalBorderStyleThick : verticalBorderStyle;
                             <td align="left" valign="middle" style=borderStyle></td>
@@ -121,7 +121,7 @@ $ const linkStyle = {
                   <common-table-spacer-element height=4 />
                   <tr>
                     <td align="left" valign="top">
-                      <table width="98%" align="right" border="0" cellspacing="0" cellpadding="0">
+                      <table width="86%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap86-84">
                         <tr>
                           <td align="left" class="font3" valign="middle">
                             <marko-core-obj-text obj=node field="teaser" html=true attrs={ style: teaserStyle } />

--- a/packages/common/components/blocks/content/new-list.marko
+++ b/packages/common/components/blocks/content/new-list.marko
@@ -79,7 +79,7 @@ $ const linkStyle = {
 }>
 
   <if(displaySectionName === true)>
-    <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+    <table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
       <tr>
         <td align="center" valign="top">
           <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101">
@@ -94,7 +94,7 @@ $ const linkStyle = {
     </table>
   </if>
   <for|node| of=nodes>
-    <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+    <table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
       <tr>
         <td align="center" valign="top">
           <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101" bgcolor="#ffffff">

--- a/packages/common/components/blocks/content/new-mid.marko
+++ b/packages/common/components/blocks/content/new-mid.marko
@@ -77,7 +77,7 @@ $ const buttonTextStyle = {
   queryFragment: contentList,
 }>
   <for|node| of=nodes>
-    <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+    <table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
       <tr>
         <td align="center" valign="top">
           <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101">
@@ -87,8 +87,8 @@ $ const buttonTextStyle = {
                   <marko-newsletter-imgix
                     src=image.src
                     alt=image.alt
-                    options={ w: 324, h: 253 }
-                    attrs={ align: "center", width: 324, height: 253 }
+                    options={ w: 360, h: 253 }
+                    attrs={ align: "center", width: 360, height: 253 }
                     class="resize_img"
                   >
                     <@link href=node.siteContext.url target="_blank" attrs={ style: nameStyle} />
@@ -112,7 +112,7 @@ $ const buttonTextStyle = {
         </td>
       </tr>
     </table>
-    <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+    <table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
       <tr>
         <td align="center" valign="top">
           <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff" class="wrap101">

--- a/packages/common/components/blocks/content/new-mid.marko
+++ b/packages/common/components/blocks/content/new-mid.marko
@@ -77,10 +77,10 @@ $ const buttonTextStyle = {
   queryFragment: contentList,
 }>
   <for|node| of=nodes>
-    <table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+    <table width="660" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
       <tr>
         <td align="center" valign="top">
-          <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101">
+          <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101">
             <tr>
               <td valign="center" width="60%" class="flt1">
                 <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
@@ -112,13 +112,13 @@ $ const buttonTextStyle = {
         </td>
       </tr>
     </table>
-    <table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+    <table width="660" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
       <tr>
         <td align="center" valign="top">
-          <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff" class="wrap101">
+          <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff" class="wrap101">
             <tr>
               <td align="center" valign="top">
-                <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap100">
+                <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap100">
                   <common-table-spacer-element height=10 />
                   <tr>
                     <td align="left" valign="top" class="mob_show1" style="display: none;">
@@ -141,37 +141,37 @@ $ const buttonTextStyle = {
       </tr>
       <tr>
         <td align="center" valign="top">
-          <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101" bgcolor="#ffffff">
+          <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101" bgcolor="#ffffff">
             <tr>
               <td align="center" valign="top">
-                <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap100">
+                <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap100">
                   <common-table-spacer-element height=11 />
                   <tr>
                     <td align="left" valign="top">
-                      <table width="100%" align="right" border="0" cellspacing="0" cellpadding="0" class="wrap103">
+                      <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101">
                         <tr>
                           <td align="left" valign="middle" class="font3">
                             <marko-core-obj-text obj=node field="teaser" attrs={ style: teaserStyle } />
                           </td>
                         </tr>
-                      </table>
-                    </td>
-                  </tr>
-                  <common-table-spacer-element height=10 />
-                  <tr>
-                    <td align="left" valign="top" class="mob_hide">
-                      <table width="120" align="left" border="0" cellspacing="0" cellpadding="0">
+                        <common-table-spacer-element height=10 />
                         <tr>
-                          <td align="center" height="30" valign="middle" style=buttonStyle>
-                            <marko-core-obj-text obj=node>
-                              <@link href=node.siteContext.url target="_blank" attrs= { style: buttonTextStyle } />VIEW ARTICLE
-                            </marko-core-obj-text>
+                          <td align="left" valign="top" class="mob_hide">
+                            <table width="120" align="left" border="0" cellspacing="0" cellpadding="0">
+                              <tr>
+                                <td align="center" height="30" valign="middle" style=buttonStyle>
+                                  <marko-core-obj-text obj=node>
+                                    <@link href=node.siteContext.url target="_blank" attrs= { style: buttonTextStyle } />VIEW ARTICLE
+                                  </marko-core-obj-text>
+                                </td>
+                              </tr>
+                            </table>
                           </td>
                         </tr>
+                        <common-table-spacer-element class="height2" height=26 />
                       </table>
                     </td>
                   </tr>
-                  <common-table-spacer-element class="height2" height=26 />
                 </table>
               </td>
             </tr>

--- a/packages/common/components/blocks/content/new-sponsored-list.marko
+++ b/packages/common/components/blocks/content/new-sponsored-list.marko
@@ -52,18 +52,18 @@ $ const sponsoredNameStyle = {
   skip: skip,
 }>
   <for|node, index| of=nodes>
-    <table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+    <table width="660" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
       <tr>
         <td align="center" valign="top">
-          <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101" bgcolor="#ffffff">
+          <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101" bgcolor="#ffffff">
             <common-table-spacer-element height=15 />
             <tr>
               <td align="center" valign="top">
-                <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap100">
+                <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap100">
                   <common-table-hr-element height="15" style="border-top: 2px solid #2f2f2f;" />
                   <tr>
                     <td align="center" valign="top">
-                      <table width="100%" align="center" border="0" cellspacing="0" cellpadding="0">
+                      <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0">
                         <tr>
                           <td align="center" width="45%">
                             <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">

--- a/packages/common/components/blocks/content/new-sponsored-list.marko
+++ b/packages/common/components/blocks/content/new-sponsored-list.marko
@@ -52,7 +52,7 @@ $ const sponsoredNameStyle = {
   skip: skip,
 }>
   <for|node, index| of=nodes>
-    <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+    <table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
       <tr>
         <td align="center" valign="top">
           <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101" bgcolor="#ffffff">

--- a/packages/common/components/blocks/new-standard-advertisement.marko
+++ b/packages/common/components/blocks/new-standard-advertisement.marko
@@ -4,13 +4,13 @@ $ const adUnit = getAsObject(input, "adUnit");
 $ const newsletter = getAsObject(input, "newsletter");
 $ const { date } = input;
 
-<table width="600" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+<table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
   <tr>
     <td align="center" valign="top">
       <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101" bgcolor="#ffffff">
         <tr>
           <td align="center" valign="top">
-            <marko-newsletters-email-x-display decoded-params=["email", "send"]>
+            <marko-newsletters-email-x-display decoded-params=["email", "send"] class="wrap100">
               <@ad-unit ...adUnit />
               <@params date=date email="@{email name}@" />
               <@image class="resize_img1" />

--- a/packages/common/components/blocks/new-standard-advertisement.marko
+++ b/packages/common/components/blocks/new-standard-advertisement.marko
@@ -4,10 +4,10 @@ $ const adUnit = getAsObject(input, "adUnit");
 $ const newsletter = getAsObject(input, "newsletter");
 $ const { date } = input;
 
-<table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+<table width="660" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
   <tr>
     <td align="center" valign="top">
-      <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101" bgcolor="#ffffff">
+      <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101" bgcolor="#ffffff">
         <tr>
           <td align="center" valign="top">
             <marko-newsletters-email-x-display decoded-params=["email", "send"] class="wrap100">

--- a/packages/common/components/blocks/new-standard-footer.marko
+++ b/packages/common/components/blocks/new-standard-footer.marko
@@ -27,10 +27,10 @@ $ const linkStyle = {
   "text-decoration": "none"
 };
 
-<table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+<table width="660" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
   <tr>
     <td align="center" valign="top">
-      <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="ffffff" class="wrap101">
+      <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="ffffff" class="wrap101">
         <tr>
           <td align="center" valign="top">
             <marko-newsletter-imgix

--- a/packages/common/components/blocks/new-standard-footer.marko
+++ b/packages/common/components/blocks/new-standard-footer.marko
@@ -27,7 +27,7 @@ $ const linkStyle = {
   "text-decoration": "none"
 };
 
-<table width="600" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+<table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
   <tr>
     <td align="center" valign="top">
       <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="ffffff" class="wrap101">
@@ -35,8 +35,8 @@ $ const linkStyle = {
           <td align="center" valign="top">
             <marko-newsletter-imgix
               src=`${newsletterConfig.footerLogoSrc}`
-              options={ w: 540, h: 93 }
-              attrs={ align: "center", width: 540, height: 93 }
+              options={ w: 600, h: 93 }
+              attrs={ align: "center", width: 600, height: 93 }
               class="resize_img"
             />
           </td>
@@ -50,8 +50,9 @@ $ const linkStyle = {
                     <td>
                       <marko-newsletter-imgix
                         src=`${socialMedia.imagePath}/${link.provider}-white.png`
+                        class="resize_img1"
                         alt=link.provider
-                        options={ w: 35, h: 34 }
+                        options={ w: 45, h: 34 }
                         attrs={ align: "center", valign: "middle" }
                       >
                         <@link href=link.href target="_blank" />

--- a/packages/common/components/blocks/new-standard-header.marko
+++ b/packages/common/components/blocks/new-standard-header.marko
@@ -15,7 +15,7 @@ $ const textStyle = {
   "text-decoration": "none",
 }
 
-<table width="600" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+<table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
   <tr>
     <td align="center" valign="top">
       <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101">
@@ -28,7 +28,7 @@ $ const textStyle = {
                   <marko-newsletter-imgix
                     src=`${newsletterConfig.headerLogoSrc}`
                     alt="logo"
-                    options={ w: 85, h: 24 }
+                    options={ w: 95, h: 24 }
                     attrs={ style: "margin: 0 0 0 8px !important; height: 24" }
                   >
                     <@link href=website.get("origin") target="_blank" />

--- a/packages/common/components/blocks/new-standard-header.marko
+++ b/packages/common/components/blocks/new-standard-header.marko
@@ -15,10 +15,10 @@ $ const textStyle = {
   "text-decoration": "none",
 }
 
-<table width="666" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
+<table width="660" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
   <tr>
     <td align="center" valign="top">
-      <table width="90%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101">
+      <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101">
         <common-table-spacer-element height=10 />
         <tr>
           <td valign="top">

--- a/packages/common/components/new-standard-head-styles.marko
+++ b/packages/common/components/new-standard-head-styles.marko
@@ -28,6 +28,7 @@
       .tpl-content { display:inline !important;}
 
       @media(max-width:620px){
+        .wrap86-84{width: 86% !important;}
         .wrap10{width: 100% !important;}
         .wrap101{width: 94% !important;}
         .wrap102{width: 94% !important;}
@@ -43,6 +44,7 @@
       @media(max-width:479px){
         .wrap100{width: 95% !important;}
         .wrap103{width: 98% !important;}
+        .wrap86-84{width: 84% !important;}
         .mob_hide{display: none !important;}
         .mob_show{display: block !important;font-size: 13px !important;line-height: 18px !important;}
         .mob_show1{display: block !important;}

--- a/tenants/sdce/config/core.js
+++ b/tenants/sdce/config/core.js
@@ -15,6 +15,7 @@ module.exports = {
     name: 'Headline News',
     primaryColor: '#e50102',
     editor: 'Marina Mayer',
+    editorTitle: 'Editor-in-Chief',
     editorImage: '/files/base/acbm/sdce/image/static/editors_marina.png',
   },
 };


### PR DESCRIPTION
![screencapture-localhost-21095-templates-headline-news-2021-09-22-14_22_21](https://user-images.githubusercontent.com/64623209/134408432-a26f10fb-d32f-45de-a86b-4e1d7c3cf7f5.png)
