### PR TITLE
Adjust styling to account for email on acid testing

### DIFF
--- a/packages/common/components/blocks/content/new-featured.marko
+++ b/packages/common/components/blocks/content/new-featured.marko
@@ -146,7 +146,7 @@ $ const buttonTextStyle = {
             </tr>
             <tr>
               <td align="center" valign="top">
-                <table width="88%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap100">
+                <table width="88%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap102">
                   <tr>
                     <td align="left" valign="top">
                       <table width="100%" align="left" valign="bottom" border="0" cellspacing="0" cellpadding="0">
@@ -167,7 +167,7 @@ $ const buttonTextStyle = {
             <common-table-spacer-element height=5 />
             <tr>
               <td align="center" valign="top">
-                <table width="88%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap100">
+                <table width="88%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap102">
                   <tr>
                     <td align="left" valign="middle">
                       <marko-core-obj-text obj=node field="teaser" html=true attrs={ style: teaserStyle } />

--- a/packages/common/components/blocks/content/new-mid.marko
+++ b/packages/common/components/blocks/content/new-mid.marko
@@ -69,7 +69,6 @@ $ const buttonTextStyle = {
   "display": "block",
 };
 
-
 <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
   date: date.valueOf(),
   newsletterId: newsletter.id,
@@ -88,7 +87,7 @@ $ const buttonTextStyle = {
                     src=image.src
                     alt=image.alt
                     options={ w: 360, h: 253 }
-                    attrs={ align: "center", width: 360, height: 253 }
+                    attrs={ align: "center", style: "display=block" }
                     class="resize_img"
                   >
                     <@link href=node.siteContext.url target="_blank" attrs={ style: nameStyle} />
@@ -144,11 +143,11 @@ $ const buttonTextStyle = {
           <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101" bgcolor="#ffffff">
             <tr>
               <td align="center" valign="top">
-                <table width="100%" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap100">
+                <table width="100%" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff" class="wrap100">
                   <common-table-spacer-element height=11 />
                   <tr>
                     <td align="left" valign="top">
-                      <table width="88%" align="center" border="0" cellspacing="0" cellpadding="0">
+                      <table width="88%" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff" class="wrap100">
                         <tr>
                           <td align="left" valign="middle" class="font3">
                             <marko-core-obj-text obj=node field="teaser" attrs={ style: teaserStyle } />
@@ -157,7 +156,7 @@ $ const buttonTextStyle = {
                         <common-table-spacer-element height=10 />
                         <tr>
                           <td align="left" valign="top" class="mob_hide">
-                            <table width="120" align="left" border="0" cellspacing="0" cellpadding="0">
+                            <table width="120" align="left" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff">
                               <tr>
                                 <td align="center" height="30" valign="middle" style=buttonStyle>
                                   <marko-core-obj-text obj=node>

--- a/packages/common/components/blocks/new-standard-advertisement.marko
+++ b/packages/common/components/blocks/new-standard-advertisement.marko
@@ -2,12 +2,13 @@ import { getAsObject } from "@parameter1/base-cms-object-path";
 
 $ const adUnit = getAsObject(input, "adUnit");
 $ const newsletter = getAsObject(input, "newsletter");
-$ const { date } = input;
+$ const { date, location } = input;
+$ const adBackgroundColor = location === 'banner-1' ? '#000101' : "#ffffff"
 
 <table width="660" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
   <tr>
     <td align="center" valign="top">
-      <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101" bgcolor="#ffffff">
+      <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" class="wrap101" bgcolor=adBackgroundColor>
         <tr>
           <td align="center" valign="top">
             <marko-newsletters-email-x-display decoded-params=["email", "send"] class="wrap100">

--- a/packages/common/components/blocks/new-standard-footer.marko
+++ b/packages/common/components/blocks/new-standard-footer.marko
@@ -36,14 +36,14 @@ $ const linkStyle = {
             <marko-newsletter-imgix
               src=`${newsletterConfig.footerLogoSrc}`
               options={ w: 600, h: 93 }
-              attrs={ align: "center", width: 600, height: 93 }
+              attrs={ width: 600, align: "center", style: "display=block" }
               class="resize_img"
             />
           </td>
         </tr>
         <if(socialMediaLinks.length)>
           <tr bgcolor=primaryColor>
-            <td align="center" valign="top"  class="align2">
+            <td align="center" valign="top" class="align2">
               <table align="center"  class="align2" border="0" cellspacing="0" cellpadding="10">
                 <tr>
                   <for|link| of=socialMediaLinks>

--- a/packages/common/components/layouts/new-standard.marko
+++ b/packages/common/components/layouts/new-standard.marko
@@ -46,6 +46,7 @@ $ const primaryColor = get(newsletterConfig, "primaryColor");
           <common-new-standard-advertisement-block
             date=date
             ad-unit=emailX.getAdUnit({ name: "banner-1", alias: newsletter.alias })
+            location="banner-1"
           />
 
           <common-content-new-list-block

--- a/packages/common/components/new-standard-head-styles.marko
+++ b/packages/common/components/new-standard-head-styles.marko
@@ -30,11 +30,9 @@
       @media(max-width:620px){
         .wrap10{width: 100% !important;}
         .wrap101{width: 94% !important;}
-        .wrap102{width: 94% !important;}
         .resize_img{width: 100% !important;height: auto !important;}
         .resize_img1{width: 96% !important;height: auto !important;}
         br{display: none !important;}
-        .height1{height: 2px !important;}
         .font2{font-size: 10px !important;line-height: 13px !important;}
         .mob_hide1{font-size: 18px !important;line-height: 23px !important;}
         .font6{font-size: 15px !important;line-height: 19px !important;}
@@ -42,24 +40,20 @@
 
       @media(max-width:479px){
         .wrap100{width: 95% !important;}
-        .wrap103{width: 98% !important;}
+        .wrap102{width: 90% !important;}
         .mob_hide{display: none !important;}
+        .mob_hide1{display: none !important;}
         .mob_show{display: block !important;font-size: 13px !important;line-height: 18px !important;}
         .mob_show1{display: block !important;}
         .font1{font-size: 18px !important;line-height: 22px !important;}
+        .font2{font-size: 8px !important;line-height: 11px !important;}
         .font3{font-size: 12px !important;line-height: 16px !important;}
         .font4{font-size: 8px !important;line-height: 11px !important;}
-        .font2{font-size: 8px !important;line-height: 11px !important;}
-        .flt1{float: none !important;display: block !important;width: 100% !important;text-align: center !important;}
         .font5{font-size: 14px !important;line-height: 17px !important;}
-        .font6{font-size: 11px !important;}
-        .mob_hide1{display: none !important;}
+        .font6{font-size: 11px !important;line-height: 17px !important;}
+        .flt1{float: none !important;display: block !important;width: 100% !important;text-align: center !important;}
         .height2{height: 6px !important;}
         .height3{height: 14px !important;}
-        .font6{font-size: 11px !important;line-height: 17px !important;}
-        .wrap102{width: 100% !important;}
-        .align{text-align: left !important;margin: 0 !important}
-        .align1{text-align: left !important;text-decoration: underline;}
         .align2{text-align: center !important;}
         .align3{text-align: center !important; text-decoration: underline;}
       }


### PR DESCRIPTION
Before:
<img width="644" alt="Screen Shot 2021-09-27 at 2 00 52 PM" src="https://user-images.githubusercontent.com/64623209/134969214-ccbe55eb-a30f-4a30-8fd3-13442831ae60.png">
After:
<img width="667" alt="Screen Shot 2021-09-27 at 1 59 13 PM" src="https://user-images.githubusercontent.com/64623209/134969237-64806352-cb07-4d5c-8414-6a55a1ee9da5.png">
Removed white space under ad:
<img width="914" alt="Screen Shot 2021-09-27 at 1 55 10 PM" src="https://user-images.githubusercontent.com/64623209/134969250-794a9960-6e3e-41a4-8987-6779df679b18.png">
