### PR TITLE
Make styling adjustments mid and footer blocks

### DIFF
--- a/packages/common/components/blocks/content/new-mid.marko
+++ b/packages/common/components/blocks/content/new-mid.marko
@@ -69,6 +69,12 @@ $ const buttonTextStyle = {
   "display": "block",
 };
 
+$ const imageStyle = {
+  "align": "center",
+  "display": "block",
+  "object-fit": "cover"
+}
+
 <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
   date: date.valueOf(),
   newsletterId: newsletter.id,
@@ -87,7 +93,7 @@ $ const buttonTextStyle = {
                     src=image.src
                     alt=image.alt
                     options={ w: 360, h: 253 }
-                    attrs={ align: "center", style: "display=block" }
+                    attrs={ style: imageStyle }
                     class="resize_img"
                   >
                     <@link href=node.siteContext.url target="_blank" attrs={ style: nameStyle} />

--- a/packages/common/components/blocks/new-standard-footer.marko
+++ b/packages/common/components/blocks/new-standard-footer.marko
@@ -27,6 +27,11 @@ $ const linkStyle = {
   "text-decoration": "none"
 };
 
+$ const imageStyle = {
+  "align": "center",
+  "display": "block",
+}
+
 <table width="660" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#000101" class="wrap10">
   <tr>
     <td align="center" valign="top">
@@ -36,7 +41,7 @@ $ const linkStyle = {
             <marko-newsletter-imgix
               src=`${newsletterConfig.footerLogoSrc}`
               options={ w: 600, h: 93 }
-              attrs={ width: 600, align: "center", style: "display=block" }
+              attrs={ width: 600, style: imageStyle }
               class="resize_img"
             />
           </td>

--- a/packages/common/components/new-standard-head-styles.marko
+++ b/packages/common/components/new-standard-head-styles.marko
@@ -36,6 +36,7 @@
         .font2{font-size: 10px !important;line-height: 13px !important;}
         .mob_hide1{font-size: 18px !important;line-height: 23px !important;}
         .font6{font-size: 15px !important;line-height: 19px !important;}
+        .flt1{float: none !important;display: block !important;width: 100% !important;text-align: center !important;}
       }
 
       @media(max-width:479px){


### PR DESCRIPTION
Before head styling class added:
<img width="538" alt="Screen Shot 2021-09-28 at 1 50 48 PM" src="https://user-images.githubusercontent.com/64623209/135148213-ee00b231-1dfd-4911-ba9f-1b3243cd1537.png">
After head styling class added:
<img width="535" alt="Screen Shot 2021-09-28 at 1 51 17 PM" src="https://user-images.githubusercontent.com/64623209/135148243-05be6365-5ff3-4629-a03c-96e4017daa4f.png">
Image height not filling table/gap:
<img width="678" alt="Screen Shot 2021-09-28 at 1 48 21 PM" src="https://user-images.githubusercontent.com/64623209/135148379-012f3831-a383-4a03-b7fa-9c749d639aa7.png">
After changes:
<img width="649" alt="Screen Shot 2021-09-28 at 1 48 44 PM" src="https://user-images.githubusercontent.com/64623209/135148403-a8a4954c-6aa4-459f-8f10-f54325b343d6.png">

