### PR TITLE
Remove limit in “lower” section

### DIFF
--- a/packages/common/components/layouts/new-standard.marko
+++ b/packages/common/components/layouts/new-standard.marko
@@ -93,7 +93,6 @@ $ const primaryColor = get(newsletterConfig, "primaryColor");
             date=date
             section-name="Lower"
             display-section-name=false
-            limit=1
             skip=2
           />
 


### PR DESCRIPTION
Currently only allowing 3 articles to show, now there is no limit
<img width="641" alt="Screen Shot 2022-01-17 at 10 56 08 AM" src="https://user-images.githubusercontent.com/64623209/149810529-ded37ab9-197f-4d09-913c-9e70631c03b7.png">
