### PR TITLE
Fix missing footer logo image for fleet-maintenance-report template

### DIFF
--- a/tenants/fcp/config/core.js
+++ b/tenants/fcp/config/core.js
@@ -72,6 +72,7 @@ module.exports = {
     ...brands.fcp,
     name: 'Fleet Maintenance',
     primaryColor: '#f26522',
+    footerLogoSrc: '/files/base/acbm/fcp/image/static/logo/new-standard-footer-logo-F26522.png',
     editor: 'Curt Bennink',
     editorTitle: 'Senior Editor',
     editorImage: '/files/base/acbm/fcp/image/static/Curt_Bennick.png',


### PR DESCRIPTION
<img width="804" alt="Screen Shot 2022-02-08 at 1 13 24 PM" src="https://user-images.githubusercontent.com/64623209/153059198-366f6397-0b40-43a6-8963-810d395c8cc2.png">
