### PR TITLE
Adjust how ads are displaying on mobile view

### DIFF
--- a/packages/common/components/blocks/content/new-sponsored-list.marko
+++ b/packages/common/components/blocks/content/new-sponsored-list.marko
@@ -66,7 +66,7 @@ $ const sponsoredNameStyle = {
                   <tr>
                     <td valign="top">
                       <table border="0" cellspacing="0" cellpadding="0">
-                        <tr>
+                        <tr class="mob_hide">
                           <td width="250" align="left">
                             <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
                               <marko-newsletter-imgix
@@ -80,7 +80,7 @@ $ const sponsoredNameStyle = {
                               <common-dpm-content node=node date=input.date />
                             </marko-core-obj-value>
                           </td>
-                          <td align="left" valign="top" class="font2" style=bodyStyle>
+                          <td align="left" valign="top" style=bodyStyle>
                             <marko-core-obj-text obj=node field="name" tag=false>
                               <@link href=`${node.siteContext.url}#cid-${node.id}` target="_blank" attrs={ style: nameStyle } />
                             </marko-core-obj-text>
@@ -94,9 +94,40 @@ $ const sponsoredNameStyle = {
                               <@link href=`${node.siteContext.url}#cid-${node.id}` target="_blank" attrs={ style: linkStyle } />
                             </marko-core-obj-text>
                             <common-dpm-content node=node date=input.date />
-                            </td>
+                          </td>
                         </tr>
                       </table>
+                    </td>
+                  </tr>
+                  <tr align="center" class="mob_show1" style="display: none;mso-hide: all;">
+                    <td>
+                      <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                        <marko-newsletter-imgix
+                          src=image.src
+                          alt=image.alt
+                          class="resize_img1"
+                        >
+                          <@link href=`${node.siteContext.url}#cid-${node.id}` target="_blank" />
+                        </marko-newsletter-imgix>
+                        <common-dpm-content node=node date=input.date />
+                      </marko-core-obj-value>
+                    </td>
+                  </tr>
+                  <tr class="mob_show1" style="display: none;mso-hide: all;">
+                    <td align="left" valign="top" style=bodyStyle>
+                      <marko-core-obj-text obj=node field="name" tag=false>
+                        <@link href=`${node.siteContext.url}#cid-${node.id}` target="_blank" attrs={ style: nameStyle } />
+                      </marko-core-obj-text>
+                      <common-dpm-content node=node date=input.date />
+                      <div>
+                        <marko-core-link href=`${node.siteContext.url}#cid-${node.id}` target="_blank" class="mob_show1" attrs={ style: sponsoredNameStyle }>Sponsored</marko-core-link>
+                        <common-dpm-content node=node date=input.date />
+                      </div>
+                      <marko-core-obj-text obj=node field="body" html=true />
+                      <marko-core-obj-text obj=node field="linkText" tag=false>
+                        <@link href=`${node.siteContext.url}#cid-${node.id}` target="_blank" attrs={ style: linkStyle } />
+                      </marko-core-obj-text>
+                      <common-dpm-content node=node date=input.date />
                     </td>
                   </tr>
                   <common-table-hr-element height="17" style="border-bottom: 2px solid #2f2f2f" />

--- a/packages/common/components/blocks/new-standard-advertisement.marko
+++ b/packages/common/components/blocks/new-standard-advertisement.marko
@@ -24,7 +24,7 @@ $ const dpm = {
                 <!-- by default, do not use the emailx click url unless explicitly requested -->
                 <common-dpm-emailx
                   ad-unit=adUnit
-                  class="scaleAd"
+                  class="scaledAd"
                   date=input.date
                   use-emailx-href=defaultValue(dpm.useEmailxHref, false)
                   when-empty=dpm.whenEmpty

--- a/packages/common/components/dpm/emailx.marko
+++ b/packages/common/components/dpm/emailx.marko
@@ -9,7 +9,7 @@ $ const useEmailxHref = defaultValue(input.useEmailxHref, false);
 $ const withHeader = defaultValue(input.withHeader, true);
 
 $ const { name, alias } = adUnit;
-$ const classNames = [`email-x-${alias}-${name}`, input.class];
+$ const classNames = [`email-x-${alias}-${name}`, input.class, "scaledAd"];
 
 <marko-newsletters-email-x-data|{ response }| decoded-params=["email", "send"]>
   <@ad-unit ...adUnit />

--- a/packages/common/components/new-standard-head-styles.marko
+++ b/packages/common/components/new-standard-head-styles.marko
@@ -30,7 +30,7 @@
       .ExternalClass img[class^=Emoji] { width: 10px !important; height: 10px !important; display: inline !important; }
       .tpl-content { display:inline !important;}
 
-      @media(max-width:620px){
+      @media(max-width:680px){
         .wrap10{width: 100% !important;}
         .wrap101{width: 94% !important;}
         .resize_img{width: 100% !important;height: auto !important;}
@@ -42,6 +42,7 @@
         .mob_show1{display: block !important;}
         .font6{font-size: 15px !important;line-height: 19px !important;}
         .flt1{float: none !important;display: block !important;width: 100% !important;text-align: center !important;}
+        .scaledAd img{max-width: 100%; height: auto !important;}
       }
 
       @media(max-width:479px){


### PR DESCRIPTION
Native-X ads will now stack & Email-X ads will "fit" within the black newsletter border
![screencapture-app-emailonacid-app-acidtest-8z5LXhXuZrbAkEVpOrmvrbDCQVgnECpcYfInDrhyB4TaZ-iphone12-15-screenshot-2022-03-03-10_25_46](https://user-images.githubusercontent.com/64623209/156608582-12cb5d18-a7bb-4b69-a8b8-50af9259ac84.png)
