### PR TITLE
Remove 2nd Email-X banner ad from ‘Fleet Maintenance Report’ nl

### DIFF
--- a/tenants/fcp/config/email-x.js
+++ b/tenants/fcp/config/email-x.js
@@ -214,12 +214,6 @@ config
       width: 600,
       height: 100,
     },
-    {
-      name: 'banner-2',
-      id: '6042442da205ff6f0dcb2138',
-      width: 600,
-      height: 100,
-    },
   ])
   .setAdUnits('lube-report', [
     {


### PR DESCRIPTION
<img width="941" alt="Screen Shot 2022-04-07 at 3 14 01 PM" src="https://user-images.githubusercontent.com/64623209/162288604-2a873c6c-71c5-4fe9-a074-e87b86960f1a.png">
