### PR TITLE
Add Outlook styling for sponsored content

### DIFF
--- a/packages/common/components/blocks/content/new-sponsored-list.marko
+++ b/packages/common/components/blocks/content/new-sponsored-list.marko
@@ -113,6 +113,7 @@ $ const sponsoredNameStyle = {
                       </marko-core-obj-value>
                     </td>
                   </tr>
+                  <!--[if !mso]><!-->
                   <tr class="mob_show1" style="display: none;mso-hide: all;">
                     <td align="left" valign="top" style=bodyStyle>
                       <marko-core-obj-text obj=node field="name" tag=false>
@@ -130,6 +131,7 @@ $ const sponsoredNameStyle = {
                       <common-dpm-content node=node date=input.date />
                     </td>
                   </tr>
+                  <!--<![endif]-->
                   <common-table-hr-element height="17" style="border-bottom: 2px solid #2f2f2f" />
                   <common-table-spacer-element height=15 />
                 </table>

--- a/packages/common/components/blocks/content/new-sponsored-list.marko
+++ b/packages/common/components/blocks/content/new-sponsored-list.marko
@@ -113,7 +113,6 @@ $ const sponsoredNameStyle = {
                       </marko-core-obj-value>
                     </td>
                   </tr>
-                  <!--[if !mso]><!-->
                   <tr class="mob_show1" style="display: none;mso-hide: all;">
                     <td align="left" valign="top" style=bodyStyle>
                       <marko-core-obj-text obj=node field="name" tag=false>
@@ -121,7 +120,9 @@ $ const sponsoredNameStyle = {
                       </marko-core-obj-text>
                       <common-dpm-content node=node date=input.date />
                       <div>
+                        <!--[if !mso]><!-->
                         <marko-core-link href=`${node.siteContext.url}#cid-${node.id}` target="_blank" class="mob_show1" attrs={ style: sponsoredNameStyle }>Sponsored</marko-core-link>
+                        <!--<![endif]-->
                         <common-dpm-content node=node date=input.date />
                       </div>
                       <marko-core-obj-text obj=node field="body" html=true />
@@ -131,7 +132,6 @@ $ const sponsoredNameStyle = {
                       <common-dpm-content node=node date=input.date />
                     </td>
                   </tr>
-                  <!--<![endif]-->
                   <common-table-hr-element height="17" style="border-bottom: 2px solid #2f2f2f" />
                   <common-table-spacer-element height=15 />
                 </table>


### PR DESCRIPTION
This will now "hide" the extra 'Sponsored' tag on Outlook Office 365, Outlook 2010, 2013, 2016, & 2019
<img width="1089" alt="Screen Shot 2022-04-13 at 10 37 24 AM" src="https://user-images.githubusercontent.com/64623209/163218519-80fe1c67-cdc4-41dd-8781-dd2ffc87d460.png">
