### PR TITLE
Remove 2nd ad slot ‘Construction Zone Safety’

### DIFF
--- a/tenants/fcp/config/email-x.js
+++ b/tenants/fcp/config/email-x.js
@@ -148,12 +148,6 @@ config
       width: 600,
       height: 100,
     },
-    {
-      name: 'banner-2',
-      id: '6165a906a6502660e0f7d5ea',
-      width: 600,
-      height: 100,
-    },
   ])
   .setAdUnits('construction-technology', [
     {


### PR DESCRIPTION
@Shinsina Missed this one... Thought she put in a duplicate entry