### PR TITLE
Add header logo for OEM Show Report

### DIFF
--- a/tenants/ooh/config/core.js
+++ b/tenants/ooh/config/core.js
@@ -108,6 +108,7 @@ module.exports = {
     ...brands.oem,
     name: 'Show Report',
     primaryColor: '#2783c2',
+    headerLogoSrc: '/files/base/acbm/ooh/image/static/logo/OEM_LOGO.png',
     footerLogoSrc: '/files/base/acbm/ooh/image/static/logo/new-standard-footer-logo-2783C2.png',
     editor: 'Lori Ditoro',
     editorTitle: 'Editor',


### PR DESCRIPTION
<img width="731" alt="Screen Shot 2022-10-12 at 3 08 21 PM" src="https://user-images.githubusercontent.com/64623209/195438069-724a0f7c-a448-416e-93d1-ea5caf7f6fb9.png">
