### PR TITLE
IronPros template ad/sponsored changes

### DIFF
--- a/tenants/fcp/config/email-x.js
+++ b/tenants/fcp/config/email-x.js
@@ -268,11 +268,5 @@ config
       width: 600,
       height: 100,
     },
-    {
-      name: 'banner-2',
-      id: '6165a95265f06a250fd8ee8b',
-      width: 600,
-      height: 100,
-    },
   ]);
 module.exports = config;

--- a/tenants/fcp/templates/breaking-ground-ironpros.marko
+++ b/tenants/fcp/templates/breaking-ground-ironpros.marko
@@ -1,1 +1,121 @@
-<common-ironpros-layout data=data />
+import { get } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const { website, config } = out.global;
+$ const { newsletter, date, dateInfo } = input;
+
+$ const showBrand = defaultValue(input.showBrand, true);
+$ const primaryImage = defaultValue(input.primaryImage, false);
+$ const emailX = config.get("emailX");
+$ const nativeX = config.getAsObject("nativeX");
+
+$ const newsletterConfig = config.get(newsletter.alias);
+$ const primaryColor = get(newsletterConfig, "primaryColor");
+
+<marko-newsletter-root
+  title=newsletter.name
+  date=date
+>
+  <@head>
+    <common-new-standard-head-styles color=primaryColor />
+  </@head>
+  <@body style="padding:0; margin:0; -webkit-text-size-adjust: 100%; background: #ffffff; font-family: 'arial', sans-serif;">
+    <table width="100%" align="center" border="0" cellspacing="0" cellpadding="0">
+      <tr>
+        <td align="center" valign="top">
+          <common-ironpros-header-block data=data bgColor=primaryColor />
+
+          <common-ironpros-advertisement-block
+            date=date
+            ad-unit=emailX.getAdUnit({ name: "banner-1", alias: newsletter.alias })
+          />
+
+          <common-content-ironpros-featured-block
+            data=data
+            newsletter=newsletter
+            date=date
+            section-name="Featured"
+            showBrand=true
+          />
+
+          <common-content-ironpros-sponsored-block
+            date=date
+            newsletter=newsletter
+            section-name="Sponsored"
+            display-sponsored-section=true
+            limit=1
+          />
+
+          <common-content-ironpros-equipment-block
+            data=data
+            newsletter=newsletter
+            date=date
+            section-name="Equipment"
+            primary-image=true
+            limit=1
+          />
+
+          <common-content-ironpros-equipment-block
+            data=data
+            newsletter=newsletter
+            date=date
+            section-name="Equipment"
+            primary-image=false
+            skip=1
+          />
+
+          <common-content-ironpros-sponsored-secondary-block
+            date=date
+            newsletter=newsletter
+            section-name="Sponsored Secondary"
+            display-sponsored-section=true
+            limit=1
+          />
+
+          <common-content-ironpros-technology-block
+            data=data
+            newsletter=newsletter
+            date=date
+            section-name="Technology"
+            primary-image=true
+            limit=1
+          />
+
+          <common-content-ironpros-technology-block
+            data=data
+            newsletter=newsletter
+            date=date
+            section-name="Technology"
+            primary-image=false
+            skip=1
+          />
+
+          <common-ironpros-advertisement-block
+            date=date
+            ad-unit=emailX.getAdUnit({ name: "banner-2", alias: newsletter.alias })
+          />
+
+          <common-content-ironpros-workwear-block
+            data=data
+            newsletter=newsletter
+            date=date
+            section-name="Workwear"
+            primary-image=true
+            limit=1
+          />
+
+          <common-content-ironpros-workwear-block
+            data=data
+            newsletter=newsletter
+            date=date
+            section-name="Workwear"
+            primary-image=false
+            skip=1
+          />
+
+          <common-ironpros-footer-block data=data />
+        </td>
+      </tr>
+    </table>
+  </@body>
+</marko-newsletter-root>

--- a/tenants/fcp/templates/headline-news-ironpros.marko
+++ b/tenants/fcp/templates/headline-news-ironpros.marko
@@ -1,1 +1,108 @@
-<common-ironpros-layout data=data />
+import { get } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const { website, config } = out.global;
+$ const { newsletter, date, dateInfo } = data;
+
+$ const showBrand = defaultValue(input.showBrand, true);
+$ const primaryImage = defaultValue(input.primaryImage, false);
+$ const emailX = config.get("emailX");
+$ const nativeX = config.getAsObject("nativeX");
+
+$ const newsletterConfig = config.get(newsletter.alias);
+$ const primaryColor = get(newsletterConfig, "primaryColor");
+
+<marko-newsletter-root
+  title=newsletter.name
+  date=date
+>
+  <@head>
+    <common-new-standard-head-styles color=primaryColor />
+  </@head>
+  <@body style="padding:0; margin:0; -webkit-text-size-adjust: 100%; background: #ffffff; font-family: 'arial', sans-serif;">
+    <table width="100%" align="center" border="0" cellspacing="0" cellpadding="0">
+      <tr>
+        <td align="center" valign="top">
+          <common-ironpros-header-block data=data bgColor=primaryColor />
+
+          <common-ironpros-advertisement-block
+            date=date
+            ad-unit=emailX.getAdUnit({ name: "banner-1", alias: newsletter.alias })
+          />
+
+          <common-content-ironpros-featured-block
+            data=data
+            newsletter=newsletter
+            date=date
+            section-name="Featured"
+            showBrand=true
+          />
+
+          <common-content-ironpros-sponsored-block
+            date=date
+            newsletter=newsletter
+            section-name="Sponsored"
+            display-sponsored-section=true
+            limit=1
+          />
+
+          <common-content-ironpros-equipment-block
+            data=data
+            newsletter=newsletter
+            date=date
+            section-name="Equipment"
+            primary-image=true
+            limit=1
+          />
+
+          <common-content-ironpros-equipment-block
+            data=data
+            newsletter=newsletter
+            date=date
+            section-name="Equipment"
+            primary-image=false
+            skip=1
+          />
+
+          <common-content-ironpros-technology-block
+            data=data
+            newsletter=newsletter
+            date=date
+            section-name="Technology"
+            primary-image=true
+            limit=1
+          />
+
+          <common-content-ironpros-technology-block
+            data=data
+            newsletter=newsletter
+            date=date
+            section-name="Technology"
+            primary-image=false
+            skip=1
+          />
+
+          <common-content-ironpros-workwear-block
+            data=data
+            newsletter=newsletter
+            date=date
+            section-name="Workwear"
+            primary-image=true
+            limit=1
+          />
+
+          <common-content-ironpros-workwear-block
+            data=data
+            newsletter=newsletter
+            date=date
+            section-name="Workwear"
+            primary-image=false
+            skip=1
+          />
+
+          <common-ironpros-footer-block data=data />
+        </td>
+      </tr>
+    </table>
+  </@body>
+</marko-newsletter-root>


### PR DESCRIPTION
Breaking Ground IronPros: 2 ad slots & 2 Sponsored ad placements:
![screencapture-localhost-21094-templates-breaking-ground-ironpros-2022-11-01-11_18_02](https://user-images.githubusercontent.com/64623209/199285628-79f02bb8-c0b7-4c17-b7b6-cb758de25d41.png)

Headline News IronPros: 1 ad slot and 1 Sponsored ad placement
![screencapture-localhost-21094-templates-headline-news-ironpros-2022-11-01-11_32_47](https://user-images.githubusercontent.com/64623209/199286524-793b1a9a-6ad1-4757-bc82-ea2c3ba86b60.png)
