### PR TITLE
Remove secondary 600x100 EmailX ad GIP Tech Report

### DIFF
--- a/tenants/gip/config/email-x.js
+++ b/tenants/gip/config/email-x.js
@@ -30,12 +30,6 @@ config
       width: 600,
       height: 100,
     },
-    {
-      name: 'banner-2',
-      id: '615b0f3ca650265e38f7a58e',
-      width: 600,
-      height: 100,
-    },
   ])
   .setAdUnits('the-pro-report', [
     {


### PR DESCRIPTION
Before:
<img width="1792" alt="Screen Shot 2022-11-09 at 3 28 57 PM" src="https://user-images.githubusercontent.com/46794001/200945948-112d7e62-95f4-44af-9d75-1faf53b3d756.png">

After:
<img width="1786" alt="Screen Shot 2022-11-09 at 3 29 25 PM" src="https://user-images.githubusercontent.com/46794001/200945953-a9c41a04-a15c-47ff-bc6c-ab30e5ab86c5.png">
