### PR TITLE
IronPros: rearrange header logos, add spacing under 2nd ad, standardize 'Sponsored' section font

### DIFF
--- a/packages/common/components/blocks/content/ironpros-sponsored-secondary.marko
+++ b/packages/common/components/blocks/content/ironpros-sponsored-secondary.marko
@@ -15,16 +15,16 @@ $ const {
 } = input;
 
 $ const nameStyle = {
-  "font-family": "Montserrat, Aril, Helvetica, sans-serif",
+  "font-family": "'Arial black', 'Arial', Helvetica, sans-serif",
   "font-size": "16px",
   "color": "#2c2e35",
-  "font-weight": "600",
+  "font-weight": "bold",
   "letter-spacing": "0px",
   "text-decoration": "none",
 }
 
 $ const bodyStyle = {
-  ...nameStyle,
+  "font-family": "'ArialMT','Arial', Helvetica, sans-serif",
   "font-size": "12px",
   "font-weight": "500",
 }

--- a/packages/common/components/blocks/content/ironpros-sponsored.marko
+++ b/packages/common/components/blocks/content/ironpros-sponsored.marko
@@ -15,7 +15,7 @@ $ const {
 } = input;
 
 $ const nameStyle = {
-  "font-family": "Montserrat, Aril, Helvetica, sans-serif",
+  "font-family": "'Arial black', 'Arial', Helvetica, sans-serif",
   "font-size": "16px",
   "color": "#2c2e35",
   "font-weight": "bold",
@@ -24,7 +24,7 @@ $ const nameStyle = {
 }
 
 $ const bodyStyle = {
-  ...nameStyle,
+  "font-family": "'ArialMT','Arial', Helvetica, sans-serif",
   "font-size": "12px",
   "font-weight": "500",
 }

--- a/packages/common/components/blocks/content/ironpros-workwear.marko
+++ b/packages/common/components/blocks/content/ironpros-workwear.marko
@@ -65,6 +65,7 @@ $ const verticalBorderStyle = {
   <for|node| of=nodes>
     <if(primaryImage)>
       <table width="660" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#ededee" class="wrap10">
+        <common-table-spacer-element height=30 />
         <tr>
           <td align="center" valign="top">
             <table width="600" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff" class="wrap101">

--- a/packages/common/components/blocks/ironpros-header.marko
+++ b/packages/common/components/blocks/ironpros-header.marko
@@ -17,11 +17,6 @@ $ const textStyle = {
   "align": "center",
 }
 
-$ const poweredByText = {
-  ...textStyle,
-  "font-size": "14px",
-}
-
 <table width="660" align="center" border="0" cellspacing="0" cellpadding="0" bgcolor="#ededee" class="wrap10">
   <tr>
     <td align="center" valign="top">
@@ -35,20 +30,20 @@ $ const poweredByText = {
                   <marko-newsletter-imgix
                     src=`${newsletterConfig.headerLogoSrc}`
                     alt="logo"
-                    options={ w: 120, h: 25 }
+                    attrs={ width: 280 }
                   >
                     <@link href=website.get("origin") target="_blank" />
                   </marko-newsletter-imgix>
                 </td>
-                <td align="center" valign="top" style=poweredByText>
+                <td align="right" valign="center" style=textStyle>
                   Powered By:
                 </td>
-                <td align="center" valign="center">
+                <td align="right" valign="center">
                   <marko-newsletter-imgix
                     src=`${newsletterConfig.fcpLogoSrc}`
                     alt="logo"
-                    options={ w: 120, h: 25 }
-                    attrs={ width: 120 }
+                    options={ w: 90, h: 25 }
+                    attrs={ width: 90 }
                   >
                     <@link href=website.get("origin") target="_blank" />
                   </marko-newsletter-imgix>
@@ -57,8 +52,8 @@ $ const poweredByText = {
                   <marko-newsletter-imgix
                     src=`${newsletterConfig.equipmentTodayLogoSrc}`
                     alt="logo"
-                    options={ w: 120, h: 25 }
-                    attrs={ width: 120 }
+                    options={ w: 90, h: 25 }
+                    attrs={ width: 90 }
                   >
                     <@link href=website.get("origin") target="_blank" />
                   </marko-newsletter-imgix>


### PR DESCRIPTION
![screencapture-localhost-21094-templates-breaking-ground-ironpros-2022-12-05-12_58_05](https://user-images.githubusercontent.com/64623209/205720402-3646e11d-d6e8-47b9-9517-f5fe949c414f.png)
