### PR TITLE
Update imgOptions for mid block

### DIFF
--- a/packages/common/components/blocks/content/new-mid.marko
+++ b/packages/common/components/blocks/content/new-mid.marko
@@ -70,8 +70,9 @@ $ const buttonTextStyle = {
 };
 
 $ const imgOptions = {
-  "fit": "crop",
-  "ar": "3:2"
+  "fit": "fill-max",
+  "fill": "solid",
+  "ar": "3:2",
 };
 
 $ const contentTypeActions = {


### PR DESCRIPTION
<img width="829" alt="Screen Shot 2023-02-13 at 8 28 38 AM" src="https://user-images.githubusercontent.com/64623209/218489753-bae4e9db-9c66-4af0-b6a6-96d5fd19f14a.png">
