### PR TITLE
Use ‘Mid’ & ‘Lower’ for Global Supply Chain newsletter sections

### DIFF
--- a/tenants/scn/templates/global-supply-chain-insights.marko
+++ b/tenants/scn/templates/global-supply-chain-insights.marko
@@ -72,11 +72,10 @@ $ const verticalBorderStyle = {
 
           <common-content-simple-list-block
             date=date
-            section-name="Main"
+            section-name="Mid"
             newsletter=newsletter
             with-image=false
             with-section=true
-            limit=2
             primary-color="#e50102"
           />
 
@@ -90,12 +89,10 @@ $ const verticalBorderStyle = {
 
           <common-content-simple-list-block
             date=date
-            section-name="Main"
+            section-name="Lower"
             newsletter=newsletter
             with-image=false
             with-section=true
-            skip=2
-            limit=7
             primary-color="#e50102"
           />
 


### PR DESCRIPTION
<img width="541" alt="Screen Shot 2023-07-11 at 8 11 53 AM" src="https://github.com/parameter1/ac-business-media-newsletters/assets/64623209/b0f25972-1d06-4475-bfe8-9d4973e5019f">
