### PR TITLE
Add wrap10 to @media:479px to prevent table size decrease

### DIFF
--- a/packages/common/components/new-standard-head-styles.marko
+++ b/packages/common/components/new-standard-head-styles.marko
@@ -47,6 +47,7 @@
       }
 
       @media(max-width:479px){
+        .wrap10{width: 100% !important;}
         .wrap100{width: 95% !important;}
         .wrap102{width: 90% !important;}
         .mob_hide{display: none !important;}


### PR DESCRIPTION
Unable to 'test'. Email on Acid doesn't show what is in the Trello card, but this would prevent the table from decreasing to 95% (staying at 100% width)