### PR TITLE
Add target=“_blank” for content links

### DIFF
--- a/packages/common/components/blocks/content/simple-list-item.marko
+++ b/packages/common/components/blocks/content/simple-list-item.marko
@@ -98,7 +98,7 @@ $ const linkLabel = input.storyLocation ? `story|${input.storyLocation}|${conten
                   <table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0" class="pad" style="padding: 0 30px 0px 0;">
                     <tr>
                       <td align="left" valign="top">
-                        <a style="font-family: 'Roboto', arial, sans-serif;font-size: 24px;line-height: 28px;color: #202022;font-weight: 700;text-decoration: none;" class="font1" href=contentUrl linklabel=linkLabel>
+                        <a style="font-family: 'Roboto', arial, sans-serif;font-size: 24px;line-height: 28px;color: #202022;font-weight: 700;text-decoration: none;" class="font1" href=contentUrl linklabel=linkLabel target="_blank">
                           $!{content.name}
                         </a>
                       </td>
@@ -174,7 +174,7 @@ $ const linkLabel = input.storyLocation ? `story|${input.storyLocation}|${conten
                             <td align="left" valign="middle" style=borderStyle></td>
                             <td align="left" valign="middle" width="7"></td>
                             <td align="left" class="font6" valign="middle" style=titleStyle>
-                              <a style="font-family: 'Roboto', arial, sans-serif;font-size: 24px;line-height: 28px;color: #202022;font-weight: 700;text-decoration: none;" href=contentUrl linklabel=linkLabel>
+                              <a style="font-family: 'Roboto', arial, sans-serif;font-size: 24px;line-height: 28px;color: #202022;font-weight: 700;text-decoration: none;" href=contentUrl target="_blank" linklabel=linkLabel>
                                 $!{content.name}
                               </a>
                             </td>


### PR DESCRIPTION
Opens in new tab
<img width="1233" alt="Screen Shot 2023-10-11 at 7 40 36 AM" src="https://github.com/parameter1/ac-business-media-newsletters/assets/64623209/927cce53-6213-4d73-ad9c-df15f9329aed">
