### PR TITLE
Update header & adjust styling for Elevating Safety newsletter

### DIFF
--- a/packages/common/components/blocks/header.marko
+++ b/packages/common/components/blocks/header.marko
@@ -63,7 +63,7 @@ $ const verticalBorderStyleThick = {
             <marko-newsletter-imgix
               src=`${newsletterConfig.headerLogoSrc}`
               alt="logo"
-              attrs={ width: 600 }
+              options={ fit: "fill", fillColor: "#ffffff"}
               class="resize_img1"
             >
               <if(newsletterConfig.headerImgLinkUrl)>

--- a/tenants/fcp/config/core.js
+++ b/tenants/fcp/config/core.js
@@ -72,7 +72,7 @@ module.exports = {
     nameFirst: 'Elevating',
     nameLast: 'Safety',
     primaryColor: '#365685',
-    headerLogoSrc: '/files/base/acbm/fcp/image/static/logo/RPN_IPAF-Header.jpeg',
+    headerLogoSrc: '/files/base/acbm/fcp/image/static/logo/IPAF-header.png',
     editor: 'Sarah Webb',
     editorTitle: 'Editor',
     editorImage: '/files/base/acbm/fcp/image/static/Sarah_Webb_headshot.png',


### PR DESCRIPTION
<img width="685" alt="Screen Shot 2024-01-03 at 12 49 46 PM" src="https://github.com/parameter1/ac-business-media-newsletters/assets/64623209/c6514540-328b-4d6a-be06-1a0f618a6b4b">
